### PR TITLE
Updated the download URL to download.elasticsearch.org

### DIFF
--- a/lib/desi/downloader.rb
+++ b/lib/desi/downloader.rb
@@ -10,13 +10,13 @@ module Desi
 
     def initialize(opts = {})
       @destination_dir = Pathname(opts.fetch(:destination_dir, Desi::LocalInstall.new))
-      @host = URI(opts.fetch(:host, 'https://nodeload.github.com/'))
+      @host = URI(opts.fetch(:host, 'https://download.elasticsearch.org/'))
       @client = opts.fetch(:http_client_factory, Desi::HttpClient).new(@host)
       @verbose = opts[:verbose]
     end
 
     def download!(version, opts = {})
-      path = "/elasticsearch/elasticsearch/tar.gz/#{version.version_name}"
+      path = "/elasticsearch/elasticsearch/#{version.filename}"
       destination_name = @destination_dir.join File.basename(version.filename)
 
       raise "ERROR: File #{destination_name} already present!" if destination_name.exist?


### PR DESCRIPTION
Because GitHub [discontinued](https://github.com/blog/1302-goodbye-uploads) their "Downloads" feature, new Elasticsearch releases and other artifacts will be available from http://download.elasticsearch.org.

This patch changes the download URL to work with the new [Elasticsearch.org download service](http://www.elasticsearch.org/blog/2012/12/17/new-download-service.html).
