### PR TITLE
Fix rspec deprecation warning.

### DIFF
--- a/spec/desi/index_manager_spec.rb
+++ b/spec/desi/index_manager_spec.rb
@@ -13,7 +13,7 @@ describe Desi::IndexManager do
 
   def stub_request(method, path, payload)
     http_client.stub(method).with(path).and_return(
-      mock("response", body: JSON.unparse(payload))
+      double("response", body: JSON.unparse(payload))
     )
   end
 


### PR DESCRIPTION
DEPRECATION: mock is deprecated. Use double instead. Called from
spec/desi/index_manager_spec.rb:16:in `stub_request'
