### PR TITLE
Fix order with es 1.0.0.

### DIFF
--- a/lib/desi/upstream.rb
+++ b/lib/desi/upstream.rb
@@ -34,7 +34,7 @@ module Desi
       protected
 
       def sortable_version
-        version_name.split('.').map {|c| c.to_i }
+        version.split('.').map {|c| c.to_i }
       end
     end
 

--- a/spec/desi/upstream_spec.rb
+++ b/spec/desi/upstream_spec.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+require "spec_helper"
+require "desi/upstream"
+
+describe Desi::Upstream::Release do
+  context "sort" do
+    let(:v1) { Desi::Upstream::Release.new("v1.0.0", "") }
+    let(:v09) { Desi::Upstream::Release.new("v0.90.10", "") }
+
+    it "sort the v1.0.0 before v0.90.10" do
+      expect([v09, v1].sort).to eql([v1, v09])
+    end
+  end
+end


### PR DESCRIPTION
Just by removing the 'v' before.
